### PR TITLE
Rename user-facing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ def my_function(): ...
 
 ```python
 # Custom readable directory name (great for organising different cache types)
-@cache(readable_dir_name="analytics")  # creates cache/analytics/ instead of cache/functions/
+@cache(symlinks_dir="analytics")  # creates cache/analytics/ instead of cache/functions/
 def analytics_function(): ...
 
-@cache(readable_dir_name="data_loading")
+@cache(symlinks_dir="data_loading")
 def load_data(): ...
 
 # Choose layout style
@@ -172,7 +172,7 @@ def data_processor(): ...
     use_tmp=False,                      # Use system temp directory
     hidden=True,                        # Prefix with dot (default)
     size_limit=2**30,                   # Max cache size (1GB default)
-    readable_dir_name="functions",      # Readable directory name
+    symlinks_dir="functions",           # Readable directory name
     split_module_path=True,             # Module/function vs flat layout
     max_arg_length=50,                  # Max argument length in paths
     symlink_name="output.parquet"       # Custom symlink filename
@@ -192,7 +192,7 @@ from plcache import PolarsCache
 # Create custom cache instance
 my_cache = PolarsCache(
     cache_dir="./analysis_cache",
-    readable_dir_name="experiments",
+    symlinks_dir="experiments",
     split_module_path=True,
     symlink_name="experiment_result.parquet"
 )
@@ -265,7 +265,7 @@ from plcache import cache
 
 @cache(
     cache_dir="./data_cache", 
-    readable_dir_name="datasets",
+    symlinks_dir="datasets",
     symlink_name="raw_data.parquet"
 )
 def load_stock_data(symbol: str, start_date: str, end_date: str) -> pl.LazyFrame:
@@ -277,7 +277,7 @@ def load_stock_data(symbol: str, start_date: str, end_date: str) -> pl.LazyFrame
 
 @cache(
     cache_dir="./analysis_cache",
-    readable_dir_name="technical_analysis", 
+    symlinks_dir="technical_analysis", 
     symlink_name="indicators.parquet"
 )
 def technical_analysis(symbol: str, window: int = 20) -> pl.DataFrame:
@@ -314,7 +314,7 @@ See the `examples/` directory for comprehensive usage examples:
 1. **Use appropriate return types**: Return `LazyFrame` for large datasets you'll filter later
 2. **Cache at the right level**: Cache expensive I/O operations, not cheap transformations  
 3. **Monitor cache size**: Set reasonable `size_limit` to avoid disk space issues
-4. **organise with `readable_dir_name`**: Use descriptive names like "experiments", "datasets", "analysis" for different cache types
+4. **organise with `symlinks_dir`**: Use descriptive names like "experiments", "datasets", "analysis" for different cache types
 5. **Custom symlink names**: Use descriptive filenames like "raw_data.parquet", "results.parquet" to identify cache contents
 
 ## License

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Human-readable symlinks are created at `{cache_dir}/functions/module/function/ar
 
 plcache creates an organised, browsable cache structure with two layout options:
 
-**Split** module path (default: `split_module_path=True`) organises cache by separate module and function directories:
+**Nested** module path (default: `nested=True`) organises cache by separate module and function directories:
 
 ```
 .polars_cache/
@@ -91,7 +91,7 @@ plcache creates an organised, browsable cache structure with two layout options:
                 └── output.parquet -> ../../../blobs/e5f6g7h8.parquet
 ```
 
-**Flat** module path (`split_module_path=False`) uses encoded full module.function names in a single directory level:
+**Flat** module path (`nested=False`) uses encoded full module.function names in a single directory level:
 
 ```
 .polars_cache/
@@ -142,10 +142,10 @@ def analytics_function(): ...
 def load_data(): ...
 
 # Choose layout style
-@cache(split_module_path=True)   # module/function/ (default)
+@cache(nested=True)   # module/function/ (default)
 def split_example(): ...
 
-@cache(split_module_path=False)  # module.function/ (flat)
+@cache(nested=False)  # module.function/ (flat)
 def flat_example(): ...
 ```
 
@@ -173,7 +173,7 @@ def data_processor(): ...
     hidden=True,                        # Prefix with dot (default)
     size_limit=2**30,                   # Max cache size (1GB default)
     symlinks_dir="functions",           # Readable directory name
-    split_module_path=True,             # Module/function vs flat layout
+    nested=True,                        # Module/function vs flat layout
     max_arg_length=50,                  # Max argument length in paths
     symlink_name="output.parquet"       # Custom symlink filename
 )
@@ -193,7 +193,7 @@ from plcache import PolarsCache
 my_cache = PolarsCache(
     cache_dir="./analysis_cache",
     symlinks_dir="experiments",
-    split_module_path=True,
+    nested=True,
     symlink_name="experiment_result.parquet"
 )
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ def flat_example(): ...
 
 ```python
 # Control argument length in directory names
-@cache(max_arg_length=20)  # truncate long argument values
+@cache(trim_arg=20)  # truncate long argument values
 def function_with_long_args(very_long_argument_name: str): ...
 
 # Custom symlink filename
@@ -174,7 +174,7 @@ def data_processor(): ...
     size_limit=2**30,                   # Max cache size (1GB default)
     symlinks_dir="functions",           # Readable directory name
     nested=True,                        # Module/function vs flat layout
-    max_arg_length=50,                  # Max argument length in paths
+    trim_arg=50,                        # Max argument length in paths
     symlink_name="output.parquet"       # Custom symlink filename
 )
 def fully_configured(): ...
@@ -208,7 +208,7 @@ def run_experiment(params: dict) -> pl.DataFrame:
 plcache handles various argument types intelligently:
 
 ```python
-@cache(max_arg_length=20)
+@cache(trim_arg=20)
 def complex_function(
     data_list: list[int],
     config: dict,
@@ -216,7 +216,7 @@ def complex_function(
     mode: str = "advanced_processing"
 ) -> pl.DataFrame:
     # Arguments are safely encoded in directory structure
-    # Long values are truncated to max_arg_length
+    # Long values are truncated to trim_arg
     return pl.DataFrame({"processed": [len(data_list)]})
 
 # Creates: functions/__main__/complex_function/arg0=[1, 2, 3]_config={'key': 'val'}_enabled=True_mode=super_long_mode_name/

--- a/examples/advanced/advanced_usage.py
+++ b/examples/advanced/advanced_usage.py
@@ -5,6 +5,7 @@ This example demonstrates various configuration options and the PolarsCache clas
 """
 
 import polars as pl
+
 from plcache import PolarsCache, cache
 
 
@@ -16,7 +17,7 @@ def demonstrate_split_vs_flat():
     # Split module path (default) - creates: cache/functions/module/function/args/
     @cache(
         cache_dir="./example_cache_split",
-        readable_dir_name="functions",
+        symlinks_dir="functions",
         split_module_path=True,
         symlink_name="result.parquet",
     )
@@ -26,7 +27,7 @@ def demonstrate_split_vs_flat():
     # Flat module path - creates: cache/functions/module.function/args/
     @cache(
         cache_dir="./example_cache_flat",
-        readable_dir_name="functions",
+        symlinks_dir="functions",
         split_module_path=False,
         symlink_name="result.parquet",
     )
@@ -57,7 +58,7 @@ def demonstrate_class_usage():
     # Create a custom cache instance
     my_cache = PolarsCache(
         cache_dir="./my_custom_cache",
-        readable_dir_name="analytics_cache",
+        symlinks_dir="analytics_cache",
         split_module_path=True,
         max_arg_length=20,  # Truncate long arguments
         symlink_name="data.parquet",
@@ -98,7 +99,7 @@ def demonstrate_custom_configurations():
     # Configuration 1: Scientific data cache
     @cache(
         cache_dir="./science_cache",
-        readable_dir_name="experiments",
+        symlinks_dir="experiments",
         split_module_path=True,
         max_arg_length=15,
         symlink_name="experiment_data.parquet",
@@ -123,7 +124,7 @@ def demonstrate_custom_configurations():
     # Configuration 2: Business analytics cache
     @cache(
         cache_dir="./analytics_cache",
-        readable_dir_name="reports",
+        symlinks_dir="reports",
         split_module_path=False,  # Flat structure for simpler browsing
         max_arg_length=30,
         symlink_name="report.parquet",

--- a/examples/advanced/advanced_usage.py
+++ b/examples/advanced/advanced_usage.py
@@ -60,7 +60,7 @@ def demonstrate_class_usage():
         cache_dir="./my_custom_cache",
         symlinks_dir="analytics_cache",
         nested=True,
-        max_arg_length=20,  # Truncate long arguments
+        trim_arg=20,  # Truncate long arguments
         symlink_name="data.parquet",
     )
 
@@ -101,7 +101,7 @@ def demonstrate_custom_configurations():
         cache_dir="./science_cache",
         symlinks_dir="experiments",
         nested=True,
-        max_arg_length=15,
+        trim_arg=15,
         symlink_name="experiment_data.parquet",
     )
     def run_simulation(
@@ -126,7 +126,7 @@ def demonstrate_custom_configurations():
         cache_dir="./analytics_cache",
         symlinks_dir="reports",
         nested=False,  # Flat structure for simpler browsing
-        max_arg_length=30,
+        trim_arg=30,
         symlink_name="report.parquet",
     )
     def generate_report(
@@ -158,9 +158,7 @@ def demonstrate_argument_handling():
     print("\n🔤 Argument Handling Examples")
     print("=" * 60)
 
-    @cache(
-        cache_dir="./args_demo", max_arg_length=25, symlink_name="args_result.parquet"
-    )
+    @cache(cache_dir="./args_demo", trim_arg=25, symlink_name="args_result.parquet")
     def complex_function(
         numbers: list[int],
         config: dict,

--- a/examples/advanced/advanced_usage.py
+++ b/examples/advanced/advanced_usage.py
@@ -18,7 +18,7 @@ def demonstrate_split_vs_flat():
     @cache(
         cache_dir="./example_cache_split",
         symlinks_dir="functions",
-        split_module_path=True,
+        nested=True,
         symlink_name="result.parquet",
     )
     def split_example(value: int) -> pl.DataFrame:
@@ -28,7 +28,7 @@ def demonstrate_split_vs_flat():
     @cache(
         cache_dir="./example_cache_flat",
         symlinks_dir="functions",
-        split_module_path=False,
+        nested=False,
         symlink_name="result.parquet",
     )
     def flat_example(value: int) -> pl.DataFrame:
@@ -59,7 +59,7 @@ def demonstrate_class_usage():
     my_cache = PolarsCache(
         cache_dir="./my_custom_cache",
         symlinks_dir="analytics_cache",
-        split_module_path=True,
+        nested=True,
         max_arg_length=20,  # Truncate long arguments
         symlink_name="data.parquet",
     )
@@ -100,7 +100,7 @@ def demonstrate_custom_configurations():
     @cache(
         cache_dir="./science_cache",
         symlinks_dir="experiments",
-        split_module_path=True,
+        nested=True,
         max_arg_length=15,
         symlink_name="experiment_data.parquet",
     )
@@ -125,7 +125,7 @@ def demonstrate_custom_configurations():
     @cache(
         cache_dir="./analytics_cache",
         symlinks_dir="reports",
-        split_module_path=False,  # Flat structure for simpler browsing
+        nested=False,  # Flat structure for simpler browsing
         max_arg_length=30,
         symlink_name="report.parquet",
     )

--- a/examples/basic/basic_usage.py
+++ b/examples/basic/basic_usage.py
@@ -31,7 +31,7 @@ def load_customer_data(n_customers: int = 1000) -> pl.DataFrame:
 
 
 # Example 2: Caching LazyFrames with custom cache directory
-@cache(cache_dir="./my_cache", readable_dir_name="analytics")
+@cache(cache_dir="./my_cache", symlinks_dir="analytics")
 def process_sales_data(multiplier: float = 1.5) -> pl.LazyFrame:
     """Process sales data and return a LazyFrame."""
     print(f"📊 Processing sales data with multiplier {multiplier}...")

--- a/examples/perf/performance_comparison.py
+++ b/examples/perf/performance_comparison.py
@@ -6,9 +6,8 @@ cached vs uncached function execution times.
 """
 
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from collections.abc import Generator
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -38,7 +37,7 @@ def expensive_data_operation(n_rows: int, delay: float = 0.1) -> pl.DataFrame:
     )
 
 
-@cache(cache_dir="./perf_cache", readable_dir_name="performance_tests")
+@cache(cache_dir="./perf_cache", symlinks_dir="performance_tests")
 def cached_data_operation(n_rows: int, delay: float = 0.1) -> pl.DataFrame:
     """Same expensive operation but with caching enabled."""
     print(f"⚡ Cached operation: {n_rows} rows (simulated delay: {delay}s)")

--- a/src/plcache/decorator.py
+++ b/src/plcache/decorator.py
@@ -30,7 +30,7 @@ class PolarsCache:
         use_tmp: bool = False,
         hidden: bool = True,
         size_limit: int = 1 * _GB,
-        readable_dir_name: str = "functions",
+        symlinks_dir: str = "functions",
         split_module_path: bool = True,
         max_arg_length: int = 50,
         symlink_name: str | None = None,
@@ -43,7 +43,7 @@ class PolarsCache:
             use_tmp: If True and cache_dir is None, put cache dir in system temp directory.
             hidden: If True, prefix directory name with dot (e.g. '.polars_cache').
             size_limit: Maximum cache size in bytes. Default: 1GB (`2**30`).
-            readable_dir_name: Name of the readable directory. Default: "functions".
+            symlinks_dir: Name of the readable directory. Default: "functions".
             split_module_path: If True, split module.function into module/function dirs.
                                If False, use percent-encoded function qualname as single dir.
             max_arg_length: Maximum length for argument values in directory names.
@@ -60,7 +60,7 @@ class PolarsCache:
 
         # Configuration
         self.symlink_name = symlink_name
-        self.readable_dir_name = readable_dir_name
+        self.symlinks_dir_name = symlinks_dir
         self.split_module_path = split_module_path
         self.max_arg_length = max_arg_length
 
@@ -74,7 +74,7 @@ class PolarsCache:
         self.parquet_dir.mkdir(exist_ok=True)
 
         # Directory for readable structure
-        self.readable_dir = self.cache_dir / self.readable_dir_name
+        self.readable_dir = self.cache_dir / self.symlinks_dir_name
         self.readable_dir.mkdir(exist_ok=True)
 
     def _get_cache_key(
@@ -130,7 +130,7 @@ class PolarsCache:
 
     def cache_polars(
         self,
-        readable_dir_name: str | None = None,
+        symlinks_dir: str | None = None,
         split_module_path: bool | None = None,
         max_arg_length: int | None = None,
         symlink_name: str | None = None,
@@ -139,15 +139,13 @@ class PolarsCache:
         Decorator for caching Polars DataFrames and LazyFrames.
 
         Args:
-            readable_dir_name: Override instance setting for readable directory name.
+            symlinks_dir: Override instance setting for readable directory name.
             split_module_path: Override instance setting for module path splitting.
             max_arg_length: Override instance setting for max argument length.
         """
         # Use instance defaults if not overridden
         use_dir_name = (
-            readable_dir_name
-            if readable_dir_name is not None
-            else self.readable_dir_name
+            symlinks_dir if symlinks_dir is not None else self.symlinks_dir_name
         )
         use_split_module = (
             split_module_path
@@ -197,12 +195,12 @@ class PolarsCache:
 
                     # Create readable symlink
                     # Temporarily override instance settings for this call
-                    old_dir_name = self.readable_dir_name
+                    old_dir_name = self.symlinks_dir_name
                     old_split = self.split_module_path
                     old_max_arg = self.max_arg_length
                     old_symlink_name = self.symlink_name
 
-                    self.readable_dir_name = use_dir_name
+                    self.symlinks_dir_name = use_dir_name
                     self.split_module_path = use_split_module
                     self.max_arg_length = use_max_arg_len
                     self.symlink_name = use_symlink_name
@@ -213,7 +211,7 @@ class PolarsCache:
                         )
                     finally:
                         # Restore instance settings
-                        self.readable_dir_name = old_dir_name
+                        self.symlinks_dir_name = old_dir_name
                         self.split_module_path = old_split
                         self.max_arg_length = old_max_arg
                         self.symlink_name = old_symlink_name
@@ -319,7 +317,7 @@ def cache(
     use_tmp: bool = False,
     hidden: bool = True,
     size_limit: int = 1 * _GB,
-    readable_dir_name: str = "functions",
+    symlinks_dir: str = "functions",
     split_module_path: bool = True,
     max_arg_length: int = 50,
     symlink_name: str | None = None,
@@ -330,7 +328,7 @@ def cache(
     Args:
         cache_dir: Directory for cache storage. If None, uses system temp directory.
         size_limit: Maximum cache size in bytes. Default: 1GB (`2 ** 30`).
-        readable_dir_name: Name of the readable directory ("functions", "cache", etc.).
+        symlinks_dir: Name of the readable directory ("functions", "cache", etc.).
         split_module_path: If True, split module.function into module/function dirs.
                           If False, use encoded full qualname as single dir.
         max_arg_length: Maximum length for argument values in directory names.
@@ -345,14 +343,14 @@ def cache(
         _global_cache = PolarsCache(
             cache_dir=cache_dir,
             size_limit=size_limit,
-            readable_dir_name=readable_dir_name,
+            symlinks_dir=symlinks_dir,
             split_module_path=split_module_path,
             symlink_name=symlink_name,
             max_arg_length=max_arg_length,
         )
 
     return _global_cache.cache_polars(
-        readable_dir_name=readable_dir_name,
+        symlinks_dir=symlinks_dir,
         split_module_path=split_module_path,
         max_arg_length=max_arg_length,
         symlink_name=symlink_name,

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ Tests the fundamental caching behavior and performance.
 ### `configuration_test.py` - Configuration Options
 Tests various configuration parameters and their effects on cache behavior.
 
-- **`test_cache_custom_dir_name`**: Verifies that custom `readable_dir_name` parameter works correctly
+- **`test_cache_custom_dir_name`**: Verifies that custom `symlinks_dir` parameter works correctly
 - **`test_max_arg_length_truncation`**: Tests that long function arguments are properly truncated in directory names according to `max_arg_length` setting
 - **`test_cache_with_kwargs`**: Ensures that functions with keyword arguments create proper directory structures including both positional and keyword arguments
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,8 +22,8 @@ Tests various configuration parameters and their effects on cache behavior.
 ### `directory_structure_test.py` - Directory Layout Patterns
 Tests how the cache organises files and directories in different structural modes.
 
-- **`test_split_module_path`**: Verifies `split_module_path=True` creates structure like `functions/module_name/function_name/args/`
-- **`test_flat_module_path`**: Verifies `split_module_path=False` creates structure like `functions/full_qualified_name/args/`
+- **`test_nested`**: Verifies `nested=True` creates structure like `functions/module_name/function_name/args/`
+- **`test_flat_module_path`**: Verifies `nested=False` creates structure like `functions/full_qualified_name/args/`
 - **`test_multiple_functions_separate_directories`**: Ensures different functions create separate directory hierarchies
 
 ### `symlinks_test.py` - Symlink Functionality

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,7 +16,7 @@ Tests the fundamental caching behavior and performance.
 Tests various configuration parameters and their effects on cache behavior.
 
 - **`test_cache_custom_dir_name`**: Verifies that custom `symlinks_dir` parameter works correctly
-- **`test_max_arg_length_truncation`**: Tests that long function arguments are properly truncated in directory names according to `max_arg_length` setting
+- **`test_trim_arg_truncation`**: Tests that long function arguments are properly truncated in directory names according to `trim_arg` setting
 - **`test_cache_with_kwargs`**: Ensures that functions with keyword arguments create proper directory structures including both positional and keyword arguments
 
 ### `directory_structure_test.py` - Directory Layout Patterns

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -42,10 +42,10 @@ def test_cache_custom_dir_name(tmp_path):
     assert expected_symlink.exists()
 
 
-def test_max_arg_length_truncation(tmp_path):
+def test_trim_arg_truncation(tmp_path):
     """Test that long arguments get truncated in directory names."""
 
-    @cache(cache_dir=tmp_path, max_arg_length=10)
+    @cache(cache_dir=tmp_path, trim_arg=10)
     def truncate_test(very_long_argument: str) -> pl.DataFrame:
         return pl.DataFrame({"result": [len(very_long_argument)]})
 

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import polars as pl
+
 from plcache import cache
 
 
@@ -9,7 +10,7 @@ def test_cache_custom_dir_name(tmp_path):
 
     @cache(
         cache_dir=tmp_path,
-        readable_dir_name="my_cache",
+        symlinks_dir="my_cache",
         symlink_name="output.parquet",
     )
     def custom_func() -> pl.DataFrame:

--- a/tests/direct_class_test.py
+++ b/tests/direct_class_test.py
@@ -11,7 +11,7 @@ def test_polars_cache_class_direct_usage(tmp_path):
     pc = PolarsCache(
         cache_dir=tmp_path,
         symlinks_dir="cached_functions",
-        split_module_path=True,
+        nested=True,
         symlink_name="result.parquet",
         max_arg_length=20,
     )

--- a/tests/direct_class_test.py
+++ b/tests/direct_class_test.py
@@ -13,7 +13,7 @@ def test_polars_cache_class_direct_usage(tmp_path):
         symlinks_dir="cached_functions",
         nested=True,
         symlink_name="result.parquet",
-        max_arg_length=20,
+        trim_arg=20,
     )
 
     @pc.cache_polars()

--- a/tests/direct_class_test.py
+++ b/tests/direct_class_test.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import polars as pl
+
 from plcache import PolarsCache
 
 
@@ -9,7 +10,7 @@ def test_polars_cache_class_direct_usage(tmp_path):
 
     pc = PolarsCache(
         cache_dir=tmp_path,
-        readable_dir_name="cached_functions",
+        symlinks_dir="cached_functions",
         split_module_path=True,
         symlink_name="result.parquet",
         max_arg_length=20,

--- a/tests/directory_structure_test.py
+++ b/tests/directory_structure_test.py
@@ -5,13 +5,13 @@ import polars as pl
 from plcache import cache
 
 
-def test_split_module_path(tmp_path):
+def test_nested(tmp_path):
     """Test cache with split module path structure."""
 
     @cache(
         cache_dir=tmp_path,
         symlinks_dir="functions",
-        split_module_path=True,
+        nested=True,
         symlink_name="result.parquet",
     )
     def test_func(n: int) -> pl.DataFrame:
@@ -21,9 +21,7 @@ def test_split_module_path(tmp_path):
 
     # Get the actual module and qualname from the function
     module_name = test_func.__module__  # Will be "tests.advanced_test" or similar
-    func_qualname = (
-        test_func.__qualname__
-    )  # Will be "test_split_module_path.<locals>.test_func"
+    func_qualname = test_func.__qualname__  # Will be "test_nested.<locals>.test_func"
 
     # Apply the same encoding as the implementation
     import urllib.parse
@@ -56,7 +54,7 @@ def test_flat_module_path(tmp_path):
 
     @cache(
         cache_dir=tmp_path,
-        split_module_path=False,
+        nested=False,
         symlink_name="cached_data.parquet",
     )
     def another_func(value: str) -> pl.DataFrame:

--- a/tests/directory_structure_test.py
+++ b/tests/directory_structure_test.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import polars as pl
+
 from plcache import cache
 
 
@@ -9,7 +10,7 @@ def test_split_module_path(tmp_path):
 
     @cache(
         cache_dir=tmp_path,
-        readable_dir_name="functions",
+        symlinks_dir="functions",
         split_module_path=True,
         symlink_name="result.parquet",
     )


### PR DESCRIPTION
Shorter for easy use

- [x] refactor: rename `readable_dir_name` to `symlinks_dir`
- [x] `split_module_path` to `nested`
- [x] `max_arg_length` to `trim_arg`